### PR TITLE
Update strong_params.rb to be Ruby 3.x compatible

### DIFF
--- a/lib/tidy_strong_params/strong_params.rb
+++ b/lib/tidy_strong_params/strong_params.rb
@@ -13,8 +13,8 @@ module TidyStrongParams
       self.scope = scope
     end
 
-    def self.restrict(*args)
-      new(*args).restrict
+    def self.restrict(**args)
+      new(**args).restrict
     end
 
     class << self


### PR DESCRIPTION
A small change to make `tidy_strong_params` Ruby 3.x compatible/